### PR TITLE
Raise an obvious error message when "urlgrabber-ext-down" is not installed

### DIFF
--- a/urlgrabber/grabber.py
+++ b/urlgrabber/grabber.py
@@ -2071,6 +2071,11 @@ import subprocess
 
 class _ExternalDownloader:
     def __init__(self):
+        # raise if urlgrabber-ext-down is not installed so the user gets a
+        # an obvious error message instead of "[Errno 5] [Errno 2] No such file
+        # or directory"
+        if not os.path.exists('/usr/libexec/urlgrabber-ext-down'):
+            raise OSError('"/usr/libexec/urlgrabber-ext-down" is not installed')
         self.popen = subprocess.Popen(
             '/usr/libexec/urlgrabber-ext-down',
             stdin = subprocess.PIPE,


### PR DESCRIPTION
I was utilizing the urlgrabber async operations in a project, but didn't have  "/usr/libexec/urlgrabber-ext-down" installed. I kept getting this traceback:

```
Traceback (most recent call last):
  File "test.py", line 11, in <module>
    grabber.parallel_wait()
  File "/usr/lib/python2.7/site-packages/urlgrabber/grabber.py", line 2351, in parallel_wait
    start(opts, 1)
  File "/usr/lib/python2.7/site-packages/urlgrabber/grabber.py", line 2195, in start
    _run_callback(opts.failfunc, opts)
  File "/usr/lib/python2.7/site-packages/urlgrabber/grabber.py", line 1030, in _run_callback
    return cb(obj)
  File "/usr/lib/python2.7/site-packages/urlgrabber/grabber.py", line 1024, in _do_raise
    raise obj.exception
urlgrabber.grabber.URLGrabError: [Errno 5] [Errno 2] No such file or directory
```

With this error, it was rather difficult to determine what file or directory was missing. After setting up some breakpoints and debugging urlgrabber, I found that I didn't have "/usr/libexec/urlgrabber-ext-down" installed, and `popen` was failing with this error.

This PR adds an exception before running `popen` if that file is missing so that is obvious as to what is going on.