### PR TITLE
Support Tokens in URLs

### DIFF
--- a/urlgrabber/mirror.py
+++ b/urlgrabber/mirror.py
@@ -94,6 +94,7 @@ CUSTOMIZATION
 import sys
 import random
 import thread  # needed for locking to make this threadsafe
+import urlparse
 
 from grabber import URLGrabError, CallbackObject, DEBUG, _to_utf8
 from grabber import _run_callback, _do_raise
@@ -394,11 +395,12 @@ class MirrorGroup:
     # by overriding the configuration methods :)
 
     def _join_url(self, base_url, rel_url):
-        if base_url.endswith('/') or rel_url.startswith('/'):
-            return base_url + rel_url
+        (scheme, netloc, path, query, fragid) = urlparse.urlsplit(base_url)
+        if path.endswith('/') or rel_url.startswith('/'):
+            return urlparse.urlunsplit((scheme, netloc, path + rel_url, query, fragid))
         else:
-            return base_url + '/' + rel_url
-        
+            return urlparse.urlunsplit((scheme, netloc, path + '/' + rel_url, query, fragid)) 
+
     def _mirror_try(self, func, url, kw):
         gr = GrabRequest()
         gr.func = func


### PR DESCRIPTION
Heya,

this makes urlgrabber support tokens in URLs. My specific use case was to mirror packages
from the SUSE Customer Center into Spacewalk.