### PR TITLE
urlgrabber-ext-down: another python 3 compat

### DIFF
--- a/scripts/urlgrabber-ext-down
+++ b/scripts/urlgrabber-ext-down
@@ -19,12 +19,17 @@
 #      Boston, MA  02111-1307  USA
 
 import time, os, errno, sys
+import six
 from urlgrabber.grabber import \
     _readlines, URLGrabberOptions, _loads, \
     PyCurlFileObject, URLGrabError
 
 def write(fmt, *arg):
-    try: os.write(1, fmt % arg)
+    buf = fmt % arg
+    if six.PY3:
+        buf = buf.encode()
+    try:
+        os.write(1, buf)
     except OSError as e:
         if e.args[0] != errno.EPIPE: raise
         sys.exit(1)
@@ -46,6 +51,8 @@ def main():
         lines = _readlines(0)
         if not lines: break
         for line in lines:
+            if not isinstance(line, six.string_types):
+                line = line.decode('utf-8')
             cnt += 1
             opts = URLGrabberOptions()
             opts._id = cnt


### PR DESCRIPTION
IMO it would be much nicer to initially fix `_readlines` function to always return string objects instead (both with Python 2 and Python 3), but now I'd have to revert/change too much stuff.

Fixes rhbz #1707657 and #1688173