### PR TITLE
Revert "Simplify mirror conversion to utf8"

### DIFF
--- a/urlgrabber/mirror.py
+++ b/urlgrabber/mirror.py
@@ -297,7 +297,12 @@ class MirrorGroup:
         self.default_action   = kwargs.get('default_action')
 
     def _parse_mirrors(self, mirrors):
-        return [{'mirror':_to_utf8(m)} for m in mirrors]
+        parsed_mirrors = []
+        for m in mirrors:
+            if isinstance(m, string_types):
+                m = {'mirror': _to_utf8(m)}
+            parsed_mirrors.append(m)
+        return parsed_mirrors
 
     def _load_gr(self, gr):
         # OVERRIDE IDEAS:


### PR DESCRIPTION
This reverts commit be8ee10e35319e80200d4ff384434d46fe7783d9.

A list of dicts (as opposed to strings) is valid input as well; see the
module-level doc string for details (section 2 under CUSTOMIZATION).  In
fact, the nested estimate() function in MirrorGroup.__init__() accounts
for that, too.

This fixes a traceback in YUM which does pass such a dict list.