### PR TITLE
Fix for usage of _levelNames from logging module

### DIFF
--- a/scripts/urlgrabber
+++ b/scripts/urlgrabber
@@ -307,7 +307,10 @@ class ugclient:
         try:
             dbinfo = dbspec.split(',')
             import logging
-            level = logging._levelNames.get(dbinfo[0], None)
+            if sys.version_info.major == 2:
+                level = logging._levelNames.get(dbinfo[0], None)
+            else:
+                level = logging._levelToName.get(dbinfo[0], None)
             if level is None: level = int(dbinfo[0])
             if level < 1: raise ValueError()
             

--- a/urlgrabber/grabber.py
+++ b/urlgrabber/grabber.py
@@ -661,7 +661,10 @@ def _init_default_logger(logspec=None):
             logspec = os.environ['URLGRABBER_DEBUG']
         dbinfo = logspec.split(',')
         import logging
-        level = logging._levelNames.get(dbinfo[0], None)
+        if sys.version_info.major == 2:
+            level = logging._levelNames.get(dbinfo[0], None)
+        else:
+            level = logging._levelToName.get(dbinfo[0], None)
         if level is None: level = int(dbinfo[0])
         if level < 1: raise ValueError()
 


### PR DESCRIPTION
With Python3 the internal dict has been renamed to _levelToName.