### PR TITLE
Fix issue when "URLGRABBER_DEBUG" is not an integer on Python3

### DIFF
--- a/urlgrabber/grabber.py
+++ b/urlgrabber/grabber.py
@@ -664,8 +664,8 @@ def _init_default_logger(logspec=None):
         if sys.version_info.major == 2:
             level = logging._levelNames.get(dbinfo[0], None)
         else:
-            level = logging._levelToName.get(dbinfo[0], None)
-        if level is None: level = int(dbinfo[0])
+            level = logging.getLevelName(dbinfo[0])
+        if level is None or not isinstance(level, int): level = int(dbinfo[0])
         if level < 1: raise ValueError()
 
         formatter = logging.Formatter('%(asctime)s %(message)s')


### PR DESCRIPTION
This PR fixes an issue when `URLGRABBER_DEBUG` environment variable is set to a non-integer value, like `DEBUG`.

Without this PR, `URLGRABBER_DEBUG=DEBUG` is not producing any debug output when running on Python 3, while it does produce the expected debug output when it runs on Python 2. 

According to the documentation, both integer or string values are valid for this environment variable:

https://github.com/rpm-software-management/urlgrabber/blob/5ac59598ab3f9f3598f6483845f6731c7a69744a/urlgrabber/grabber.py#L634-L657