### PR TITLE
Fix for TextMeter as progress_option

### DIFF
--- a/urlgrabber/progress.py
+++ b/urlgrabber/progress.py
@@ -220,7 +220,7 @@ def text_meter_total_size(size, downloaded=0):
 #
 
 def _term_add_bar(tl, bar_max_length, pc):
-    blen = bar_max_length
+    blen = int(bar_max_length)
     bar  = '='*int(blen * pc)
     if (blen * pc) - int(blen * pc) >= 0.5:
         bar += '-'
@@ -644,7 +644,7 @@ class RateEstimator:
         self.start_time = now
         self.last_update_time = now
         self.last_amount_read = 0
-        self.ave_rate = None
+        self.ave_rate = 0
 
     def update(self, amount_read, now=None):
         if now is None: now = time.time()


### PR DESCRIPTION
Type errors would prevent `TextMeter` from being used as a `progess_option`.
This commit fixes this with a type cast and an initialization of a variable as int.

Fixes #24 

Thanks to @jchax for tracking this down and providing the fix.