### PR TITLE
Use binary mode when reopening files

### DIFF
--- a/urlgrabber/grabber.py
+++ b/urlgrabber/grabber.py
@@ -1867,7 +1867,7 @@ class PyCurlFileObject(object):
                     raise err
             # re open it
             try:
-                self.fo = open(self.filename, 'r')
+                self.fo = open(self.filename, 'rb')
             except IOError as e:
                 err = URLGrabError(16, _('error opening file from %s, IOError: %s')
                                    % (self.url, e))


### PR DESCRIPTION
This PR fixes an issue in version 4.1 when interacting directly with the `PyCurlFileObject` object:

```
Traceback (most recent call last):
  File "test_urlgrabber.py", line 4, in <module>
    pycurl_obj.fo.read()
  File "/usr/lib64/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0 in position 285: invalid start byte
```

Apparently the re opening mechanism for the downloaded file is not using binary mode as it is expected.

You can easily reproduce this by running this example:

```python
import urlgrabber
url = "https://www.google.com/index.html"
pycurl_obj = urlgrabber.grabber.PyCurlFileObject(url, "index.html", urlgrabber.grabber.URLGrabberOptions())
pycurl_obj.fo.read()
```

This PR fixes this issue and allow manual `PyCurlFileObject` interaction to work fine.