### PR TITLE
Convert "dict_keys" to list to avoid crashing when delegate is enabled

### DIFF
--- a/urlgrabber/grabber.py
+++ b/urlgrabber/grabber.py
@@ -1099,7 +1099,7 @@ class URLGrabberOptions:
         return self.format()
 
     def format(self, indent='  '):
-        keys = self.__dict__.keys()
+        keys = list(self.__dict__.keys())
         if self.delegate is not None:
             keys.remove('delegate')
         keys.sort()


### PR DESCRIPTION
This PR fixes a small issue that we just found when we set `URLGRABBER_DEBUG=1` to get debug logging:

```python
12:28:12 Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/urlgrabber/grabber.py", line 808, in urlgrab
    return default_grabber.urlgrab(url, filename, **kwargs)
  File "/usr/lib/python3.6/site-packages/urlgrabber/grabber.py", line 1204, in urlgrab
    if DEBUG: DEBUG.debug('combined options: %r' % (opts,))
  File "/usr/lib/python3.6/site-packages/urlgrabber/grabber.py", line 1091, in __repr__
    return self.format()
  File "/usr/lib/python3.6/site-packages/urlgrabber/grabber.py", line 1096, in format
    keys.remove('delegate')
AttributeError: 'dict_keys' object has no attribute 'remove'
```
