### PR TITLE
Fix schema comparison to work with expected bytes string

### DIFF
--- a/urlgrabber/grabber.py
+++ b/urlgrabber/grabber.py
@@ -1233,7 +1233,7 @@ class URLGrabber(object):
             if not filename:
                 # This is better than nothing.
                 filename = 'index.html'
-        if scheme == 'file' and not opts.copy_local:
+        if scheme == b'file' and not opts.copy_local:
             # just return the name of the local file - don't make a
             # copy currently
             path = url2pathname(path)

--- a/urlgrabber/grabber.py
+++ b/urlgrabber/grabber.py
@@ -1236,9 +1236,9 @@ class URLGrabber(object):
         if scheme == b'file' and not opts.copy_local:
             # just return the name of the local file - don't make a
             # copy currently
-            path = url2pathname(path)
+            path = url2pathname(_urlunquote_convert(path))
             if host:
-                path = os.path.normpath('//' + host + path)
+                path = os.path.normpath('//' + _urlunquote_convert(host) + path)
             if not os.path.exists(path):
                 err = URLGrabError(2,
                       _('Local file does not exist: %s') % (path, ))


### PR DESCRIPTION
The `urlgrab` function initially coverts the given `url` to bytes string via the `_to_utf8()` helper.

This makes the final `url` parameter to be bytes, and therefore we need to fix this comparison to work properly.